### PR TITLE
Fix "last game" list of players bug

### DIFF
--- a/src/org/systemcall/scores/AddPlayersActivity.java
+++ b/src/org/systemcall/scores/AddPlayersActivity.java
@@ -75,9 +75,6 @@ public class AddPlayersActivity extends Activity {
 		userName = userName.trim();
 		if (userName.length() == 0)
 			return;
-		if (users.length() > 0)
-			users += ",";
-		users += userName;
 		_addUser(userName);
 		textView.setText("");
 	}
@@ -88,6 +85,9 @@ public class AddPlayersActivity extends Activity {
 		TextView user = new TextView(this);
 		user.setTextSize(20);
 		user.setText(userName);
+        if (users.length() > 0)
+            users += ",";
+        users += userName;
 		userList.addView(user);
 	}
 


### PR DESCRIPTION
Previously, when adding names to the list, wouldn't add them to
the game list, just to the preferences, so when loading names from a
previous game, you'd get them on the list, but not on the game.

Fixes #8